### PR TITLE
Preserve trailing newline in haproxy config

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -5,7 +5,7 @@ metadata:
   name: postgres-haproxy-port-forward-$SUFFIX
   namespace: $NAMESPACE
 data:
-  haproxy.cfg: |-
+  haproxy.cfg: |
     global
     defaults
         timeout connect 30s


### PR DESCRIPTION
Fixes the issue in haproxy.cfg: `Missing LF on last line, file might have been truncated at position 94`

```
~ ☸️· production (unternehmen-one-stop-shop-production)
➜ k get po
NAME                                                    READY   STATUS      RESTARTS      AGE
postgres-forward-pod-4f4da531471e                       0/1     Error       1 (13s ago)   17s
...

~ ☸️· production (unternehmen-one-stop-shop-production)
➜ k logs postgres-forward-pod-4f4da531471e
[NOTICE]   (1) : haproxy version is 3.4.1-3e888a769
[ALERT]    (1) : config : parsing [/usr/local/etc/haproxy/haproxy.cfg:13]: Missing LF on last line, file might have been truncated at position 94.
[ALERT]    (1) : config : Error(s) found in configuration file : /usr/local/etc/haproxy/haproxy.cfg
[ALERT]    (1) : config : Fatal errors found in configuration.
```