### PR TITLE
Await pod readiness

### DIFF
--- a/db-forward.sh
+++ b/db-forward.sh
@@ -83,6 +83,9 @@ _run_up() {
 	printf 'Waiting for pod to run ...\n'
 	kubectl --namespace="${NAMESPACE}" wait --for=jsonpath='{.status.phase}'=Running "pod/postgres-forward-pod-${SUFFIX}"
 
+	printf 'Waiting for pod to be ready ...\n'
+	kubectl --namespace="${NAMESPACE}" wait --for=condition=Ready --timeout=120s "pod/postgres-forward-pod-${SUFFIX}"
+
 	printf 'Starting port forwarding ...\n'
 	nohup kubectl --namespace="${NAMESPACE}" port-forward "pod/postgres-forward-pod-$SUFFIX" "$DATABASE_LOCAL_PORT:$DATABASE_PORT" >/dev/null 2>&1 &
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -42,6 +42,12 @@ spec:
       image: haproxy:3.4-alpine
       name: postgres-forward-pod
       resources: {}
+      readinessProbe:
+        tcpSocket:
+          port: 5432
+        initialDelaySeconds: 1
+        periodSeconds: 2
+        failureThreshold: 30
       volumeMounts:
         - mountPath: /usr/local/etc/haproxy/
           name: postgres-haproxy-port-forward


### PR DESCRIPTION
Before, it would not be transparent to the user of the script that the pod might be crashing or errorous (see #5)
